### PR TITLE
Added case for failed services

### DIFF
--- a/check_service.sh
+++ b/check_service.sh
@@ -252,6 +252,10 @@ case $STATUS_MSG in
         echo "Error in command: $STATUS_MSG"
         exit $CRITICAL
         ;;
+*[fF]ailed*)
+        echo "$STATUS_MSG"
+        exit $CRITICAL
+        ;;
 *[eE]nable*)
         echo "$STATUS_MSG"
         exit $OK


### PR DESCRIPTION
check_service returns OK for stopped systemd services where the active attribute is failed