### PR TITLE
Add Warning support and Nagios output for -T status

### DIFF
--- a/check_bro.sh
+++ b/check_bro.sh
@@ -234,10 +234,10 @@ do
 done
 
   if [ $STOPPED -gt 0 ] || [ $CRASHED -gt 0 ] || [ $UNKNOWN_WORKER -gt 0 ]; then
-    echo "$CHECK_NAME CRITICAL - $STOPPED stopped workers, $CRASHED crashed workers, $RUNNING running workers, and $UNKNOWN_WORKER workers with an unknown status |$MESSAGE"
+    echo "$CHECK_NAME CRITICAL - $STOPPED stopped workers, $CRASHED crashed workers, $RUNNING running workers, and $UNKNOWN_WORKER workers with an unknown status:$MESSAGE"
     exit $CRITICAL
   else
-    echo "$CHECK_NAME OK - All $RUNNING instances are running |$MESSAGE"
+    echo "$CHECK_NAME OK - All $RUNNING instances are running:$MESSAGE"
     exit $OK
   fi
 fi

--- a/check_bro.sh
+++ b/check_bro.sh
@@ -208,34 +208,36 @@ if [ $STATUS_CHECK -eq 1 ]; then
 
 # Broctl stderr is whitespace separated and we need to match on entire line
 IFS=$'\n'
-for line in $($BROCTL status 2>&1 | grep -v 'Name\|waiting')
+MESSAGE=""
+CHECK_NAME="BROCTL STATUS"
+for line in $($BROCTL status 2>&1 | grep -v 'Name\|waiting\|Warning')
 do
   NAME=$(echo "$line" | awk '{ print $1 }')
   case "$line" in
   *stop*)
-    echo "$NAME has stopped"
+    MESSAGE="$MESSAGE $NAME has stopped,"
     STOPPED=$((STOPPED+1))
     ;;
   *fail*)
-    echo "$NAME has crashed"
+    MESSAGE="$MESSAGE $NAME has crashed,"
     CRASHED=$((CRASHED+1))
     ;;
   *run*)
-    echo "$NAME is running"
+    MESSAGE="$MESSAGE $NAME is running,"
     RUNNING=$((RUNNING+1))
     ;;
   *)
-    echo "Unknown status of worker: $NAME"
+    MESSAGE="$MESSAGE Unknown status of worker: $NAME,"
     UNKNOWN_WORKER=$((UNKNOWN_WORKER+1))
     ;;
   esac
 done
 
   if [ $STOPPED -gt 0 ] || [ $CRASHED -gt 0 ] || [ $UNKNOWN_WORKER -gt 0 ]; then
-    echo "-> $STOPPED stopped workers, $CRASHED crashed workers, $RUNNING running workers, and $UNKNOWN_WORKER workers with an unknown status"
+    echo "$CHECK_NAME CRITICAL - $STOPPED stopped workers, $CRASHED crashed workers, $RUNNING running workers, and $UNKNOWN_WORKER workers with an unknown status |$MESSAGE"
     exit $CRITICAL
   else
-    echo "All $RUNNING instances are running!"
+    echo "$CHECK_NAME OK - All $RUNNING instances are running |$MESSAGE"
     exit $OK
   fi
 fi


### PR DESCRIPTION
- Add Warning support:
When configuration changes (on node.cfg for instance), the first line of broctl status is a warning about that change

- Nagios output:
Follow the format: <Name of plugin> <state> - <output>
described at https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html
(didn't include output as performance data using separator |)