### PR TITLE
PID ending in ZERO BUG, Modified RegEx

### DIFF
--- a/check_service.sh
+++ b/check_service.sh
@@ -311,7 +311,7 @@ case $STATUS_MSG in
         echo "$STATUS_MSG"
         exit $CRITICAL
         ;;
-[1-9][1-9]*)
+[1-9][0-9]*)
         echo "$SERVICE running: $STATUS_MSG"
         exit $OK
         ;;


### PR DESCRIPTION
Line 314 - Modified RegEx
On OSX If PID ends in '0' - no match is made, and Unknown status is erroneously returned.
Unknown status: 60      0       com.promise.sanlinkdaemon
Is there a typo in the command or service configuration?: 60    0       com.promise.sanlinkdaemon