### PR TITLE
bugfix: script will throw errors if -t parameter is used - need to in…

### DIFF
--- a/check_service.sh
+++ b/check_service.sh
@@ -23,6 +23,11 @@ WARNING=1
 CRITICAL=2
 UNKNOWN=3
 
+# Weather or not we can trust the exit code from the service management tool.
+# Defaults to 0, put to 1 for systemd.  Otherwise we must rely on parsing the
+# output from the service management tool.
+TRUST_EXIT_CODE=0
+
 usage()
 {
 cat <<EOF
@@ -68,7 +73,6 @@ fi
 
 
 determine_service_tool() {
-TRUST_EXIT_CODE=0
 if [[ $OS == linux ]]; then
         if command -v systemctl >/dev/null 2>&1; then
                 SERVICETOOL="systemctl status $SERVICE"


### PR DESCRIPTION
I have an issue with Trusty ... "status $foo" throws an error "unknown job", while "service $foo status" works.  Well, the obvious workaround is to use "-t 'service $foo status'", but then I got this error:

    /usr/lib/nagios/plugins/check_service.sh: line 249: [: -eq: unary operator expected

This pull request should fix it, by initializing the default value for the $TRUST_EXIT_STATUS at the top of the script rather than in the function for finding the service management tool command.

(actually, this seems to be a bug introduced in my previous pull request).